### PR TITLE
CSS Transitions!

### DIFF
--- a/bicycle-banh-mi/css/style.css
+++ b/bicycle-banh-mi/css/style.css
@@ -10,6 +10,23 @@
   background-image: url(../assets/bbm3.jpg);
 }
 
+.carousel-image {
+  transition: opacity 0.3s ease-in;
+  transition: transform 0.2s ease-in-out;
+}
+
+.active .carousel-image {
+  opacity: 0.9;
+  transform: scale(1.0);
+}
+
+/* used for images entering/leaving */
+.left .carousel-image, .right .carousel-image {
+  opacity: 0.7;
+  transform: scale(0.9);
+}
+
+
 .btn-menu {
   border-radius: 50%;
 }

--- a/bicycle-banh-mi/index.html
+++ b/bicycle-banh-mi/index.html
@@ -36,19 +36,19 @@
           <!-- Photos and captions -->
           <div class="carousel-inner" role="listbox">
             <div class="item active">
-              <div class="carousel-image-1"></div>
+              <div class="carousel-image carousel-image-1"></div>
               <div class="carousel-caption">
                 Listicle kinfolk trust fund salvia. Williamsburg man bun etsy, disrupt everyday carry tumblr jean shorts mustache offal. Etsy health goth twee intelligentsia hashtag, bitters ennui tofu bushwick tousled literally.
               </div>
             </div>
             <div class="item">
-              <div class="carousel-image-2"></div>
+              <div class="carousel-image carousel-image-2"></div>
               <div class="carousel-caption">
                 Kitsch drinking vinegar sustainable austin portland hella, health goth fanny pack pop-up. Squid art party four loko echo park salvia crucifix. Seitan craft beer polaroid, synth 3 wolf moon cred hammock readymade kogi.
               </div>
             </div>
             <div class="item">
-              <div class="carousel-image-3"></div>
+              <div class="carousel-image carousel-image-3"></div>
               <div class="carousel-caption">
                 Affogato 90's neutra slow-carb marfa church-key. Art party seitan schdivtz cedivac crucifix retro. Ramps four dollar toast vice seitan banjo. Mixtape mustache offal, pour-over thundercats selfies selvage.
               </div>


### PR DESCRIPTION
Adds some CSS transitions so images scale up/down and fade in/out when entering/leaving.

If we want to actually have the images to scale when they're sliding, I think we might need to rehaul the JS (i.e. move away from the Bootstrap carousel).

Please invoice Jess for 2 pandans as per the fork name.
